### PR TITLE
switch to hash location strategy

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -57,7 +57,7 @@ const routes: Routes = [
 ];
 
 @NgModule({
-  imports: [RouterModule.forRoot(routes)],
+    imports: [RouterModule.forRoot(routes, {useHash: true})],
   exports: [RouterModule]
 })
 


### PR DESCRIPTION
to prevent issues with 404s and deeplinks with surge, use the hash location strategy for routing

currently deep links result in 404, like http://app.code4socialgood.org/project/list

this PR would change the routing to look like

http://app.code4socialgood.org/#/user/list

which, while not ideal, can easily be switched later if desired.