### PR TITLE
disable forced SSL in heroku server

### DIFF
--- a/server.js
+++ b/server.js
@@ -20,7 +20,8 @@ const forceSSL = function () {
 };
 
 // instruct app to use forceSSL middleware
-app.use(forceSSL());
+// todo: enable this when SSL is enabled for the servers
+// app.use(forceSSL());
 
 app.use(express.static(__dirname + '/dist'));
 


### PR DESCRIPTION
## Motivation

this is causing issues with http://dev.code4socialgood.org/ , always redirecting to `https` which fails because SSL has not been configured yet :cry: 