### PR TITLE
3 featured projects' titles are centered and cards don't stretch along…

### DIFF
--- a/src/app/home/home.component.scss
+++ b/src/app/home/home.component.scss
@@ -299,10 +299,22 @@
     border: 1px $secondary-color solid;
     .card-content{
         text-align: center;
+        position: relative;
+        .material-icons{
+          position: absolute;
+          right: 0;
+        }
+    }
+    .card-reveal{
+      .material-icons{
+        position: absolute;
+        top: 10px;
+        right: 10px;
+      }
     }
 }
 .card-image{
-    height: 100%;
+    height: 150px;
     img{
         max-width: 100%;
         max-height: 100%;


### PR DESCRIPTION
… with the size of card images. Resolved the first issue of issue #1307 

![screen shot 2017-09-22 at 3 18 48 pm](https://user-images.githubusercontent.com/16580897/30766370-620af89a-9fa9-11e7-82f0-aa186e40e82f.png)
