### PR TITLE
Add new heroku dev profile

### DIFF
--- a/.angular-cli.json
+++ b/.angular-cli.json
@@ -31,6 +31,7 @@
       "environmentSource": "environments/environment.ts",
       "environments": {
         "dev_local": "environments/environment.dev-local.ts",
+        "dev_local_heroku": "environments/environment.dev-heroku.ts",
         "dev_remote": "environments/environment.dev-remote.ts",
         "staging_remote": "environments/environment.staging-remote.ts",
         "prod_remote": "environments/environment.prod-remote.ts"

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "serve": "ng serve",
     "start": "node server.js",
     "start:dev:local": "ng serve --environment=dev_local",
+    "start:dev:heroku": "ng serve --environment=dev_local_heroku",
     "build": "ng build",
     "test": "ng test",
     "test_single_run": "ng test --single-run",

--- a/src/environments/environment.dev-heroku.ts
+++ b/src/environments/environment.dev-heroku.ts
@@ -1,0 +1,14 @@
+export const environment = {
+    production: false,
+    backend_url: 'https://c4sg-dev.herokuapp.com',
+    auth_clientID: 'oO8PRySIJnGHDGsZQ36zOhhccNE6iNjf',
+    auth_domain: 'c4sg-dev.auth0.com',
+    auth_tenant_shared: false,
+    auth_api: 'https://c4sg-api',
+    auth_callback_env: 'local',
+    auth_silenturl: 'silent-dev-local.html',
+    AWS_IMAGE_BUCKET: 'c4sg.dev.images',
+    AWS_DOCS_BUCKET: 'c4sg.dev.docs',
+    AWS_REGION: 'us-west-2',
+    AWS_SIGNATURE_VERSION: 'v4'
+};


### PR DESCRIPTION
Add new profile that enables running backend using heroku dev environment.
 - Frontend developers will be able to use `npm run start:dev:heroku`