### PR TITLE
Fix overextended line on Project page

### DIFF
--- a/src/app/_style/app.sidebar.scss
+++ b/src/app/_style/app.sidebar.scss
@@ -141,6 +141,8 @@
   padding-bottom: 40px;
   border-bottom: solid $line-sep-width $border-color;
 
+  width: 100%;
+
  /* padding: 10px;
   border-bottom: solid $line-sep-width $border-color;
   @include small-paragraph;

--- a/src/app/project/view/project-view.component.scss
+++ b/src/app/project/view/project-view.component.scss
@@ -108,6 +108,5 @@
 }
 
 .divalign {
-margin-left: -15px;
 font-size: 12px;
 }


### PR DESCRIPTION
 - Fixed problem  referenced  [here](https://github.com/Code4SocialGood/c4sg-web/issues/1386) where gray line in sidebar of Project page extends beyond its box. 
 - Removed the -15px margin on the `.div-align` class that was causing the bottom border to extend outside of the container
- Set width of `.section .section-body-organization` to 100% to center content after removing margin from `.div-align`
- Closes issue #1386 

##### Desktop after fix
<img width="1277" alt="screen shot 2017-10-17 at 4 46 32 pm" src="https://user-images.githubusercontent.com/25699277/31693334-422b447e-b35b-11e7-8261-bf0f61fe935f.png">

##### Mobile after fix
<img width="351" alt="screen shot 2017-10-17 at 4 47 08 pm" src="https://user-images.githubusercontent.com/25699277/31693362-6de3fd5e-b35b-11e7-9dd9-ffc7dab63cd0.png">
