### PR TITLE
 Fix issue #1623 Volunteer Heroes Page - Display Country Code

### DIFF
--- a/src/app/appreciations/appreciations.component.html
+++ b/src/app/appreciations/appreciations.component.html
@@ -25,9 +25,9 @@
         <div class="user-title">{{hero.title}}</div>
         <div class="location clearfix">
           <span class="label">Location</span>
-          <span class="label-content" [class.hide]="hero.state && hero.country">{{hero.state+", "+hero.country}}</span>
-          <span class="label-content" *ngIf="!hero.state && hero.country">{{hero.country}}</span>
-          <span class="label-content" [class.hide]="!hero.country && hero.state">{{hero.state}}</span>
+          <span class="label-content" *ngIf="hero.country">{{hero.country}}</span>
+          <span class="label-content" *ngIf="!hero.country && hero.state">{{hero.state}}</span>
+          <span class="label-content" *ngIf="!hero.country && !hero.state">UNKNOWN</span>
         </div>
         <div class="badges clearfix">
           <span class="label">Badges</span>


### PR DESCRIPTION
Change Sate to Country Code in Volunteer Heroes Page. But there are some users may not have country info. I assume it should display State name if there is no Country info. And if there is no Country and State, it should Display Unknown.  Or we can not display "Location" Label at all if there is no Country info for user.