### PR TITLE
display limited number of skill tags (#1601)

### DIFF
--- a/src/app/_components/project-card-small/project-card-small.component.html
+++ b/src/app/_components/project-card-small/project-card-small.component.html
@@ -10,13 +10,7 @@
         <div class="name">
           <a [routerLink]="['/project/view/', project.id]">{{project.name}}</a>
         </div>
-        <div>
-          <div class="skills-tag-wrapper">
-            <ul *ngIf="project.skills">
-              <li class="chip" *ngFor="let skill of project.skills">{{ skill }}</li>
-            </ul>
-          </div>
-        </div>
+        <my-tags [tags]="project.skills" [max]="3" moreUrl="project/view/{{project.id}}"></my-tags>
       </div>
     </div>
     <p class="description" *ngIf="project && project.description">{{ project && project.description | slice:0:100 }} ...</p>

--- a/src/app/_components/project-card/project-card.component.html
+++ b/src/app/_components/project-card/project-card.component.html
@@ -69,11 +69,7 @@
         </div>
       </div>
       </div>
-      <div class="skills-tag-wrapper">
-        <ul *ngIf="project.skills">
-          <li class="chip" *ngFor="let skill of project.skills">{{ skill }}</li>
-        </ul>
-      </div>
+      <my-tags [tags]="project.skills" [max]="4" moreUrl="project/view/{{project.id}}"></my-tags>
       <p class="description text-overflow" *ngIf="project && project.description">{{ project && project.description }}</p>
     </div>
   </div>

--- a/src/app/_components/tags/tags.component.html
+++ b/src/app/_components/tags/tags.component.html
@@ -1,0 +1,8 @@
+<div class="skills-tag-wrapper">
+  <ul *ngIf="tags">
+    <li class="chip" *ngFor="let tag of visibleTags">{{tag}}</li>
+    <li class="chip-more" *ngIf="remainingTagsCount">
+        <a [href]="moreUrl">{{remainingTagsCount}} more</a>
+    </li>
+  </ul>
+</div>

--- a/src/app/_components/tags/tags.component.ts
+++ b/src/app/_components/tags/tags.component.ts
@@ -1,0 +1,34 @@
+import { Component, OnInit, Input } from '@angular/core';
+
+@Component({
+  selector: 'my-tags',
+  templateUrl: './tags.component.html'
+})
+export class TagsComponent implements OnInit {
+
+  @Input() tags: Array<string>;
+  @Input() moreUrl: string;
+  @Input() max: number;
+
+  constructor() { }
+
+  ngOnInit() {
+  }
+
+  get visibleTags() {
+    if ( this.max ) {
+      return this.tags.slice(0, this.max);
+    } else {
+      return this.tags;
+    }
+  }
+
+  get remainingTagsCount() {
+    if ( this.max && this.tags.length > this.max ) {
+      return this.tags.length - this.max;
+    } else {
+      return 0;
+    }
+  }
+
+}

--- a/src/app/_style/app.theme.scss
+++ b/src/app/_style/app.theme.scss
@@ -181,12 +181,26 @@ hr {
       text-align: center;
       font-size: 0.7em;
       margin: 5px 2px;
-      //cursor: pointer;
-      //&:hover {
-      //  background: #8dcdc1;
-      //}
       &:first-child {
         margin-left: 0;
+      }
+    }
+    .chip-more {
+      float: left;
+      display: inline-block;
+      color: #5ba55b;
+      font-weight: bold;
+      background: white;
+      text-align: center;
+      font-size: 0.7em;
+      margin: 5px 2px;
+      a {
+        color: inherit;
+        font-weight: inherit;
+        font-size: inherit;
+        &:hover {
+            text-decoration: underline;
+        }
       }
     }
   }
@@ -235,7 +249,7 @@ font-size: 1em;
   padding: 0;
 }
 
-.chip {
+.chip, .chip-more {
   height: 18px;
   line-height: 18px;
   padding: 0 5px;

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -75,6 +75,7 @@ import { Http, RequestOptions } from '@angular/http';
 import {AuthHttp, AuthConfig} from 'angular2-jwt';
 import { InputFormatterDirective } from './project/common/input.formatter.directive';
 import { ProjectImageComponent } from './project/common/project-image.component';
+import { TagsComponent } from './_components/tags/tags.component';
 
 export function authHttpServiceFactory(http: Http, options: RequestOptions) {
   return new AuthHttp(new AuthConfig({
@@ -141,7 +142,8 @@ export function authHttpServiceFactory(http: Http, options: RequestOptions) {
     UserAvatarHeaderComponent,
     MyPaginationControlsComponent,
     InputFormatterDirective,
-    ProjectImageComponent
+    ProjectImageComponent,
+    TagsComponent
   ],
   providers: [ProjectService,
     OrganizationService,

--- a/src/app/user/list/user-list.component.html
+++ b/src/app/user/list/user-list.component.html
@@ -88,11 +88,7 @@
                           </div>
                         </div>
                       </div>
-                      <div class="skills-tag-wrapper">
-                        <ul *ngIf="user.skills">
-                          <li class="chip" *ngFor="let skill of user.skills">{{ skill }}</li>
-                        </ul>
-                      </div>
+                      <my-tags [tags]="user.skills" [max]="5" moreUrl="user/view/{{user.id}}"></my-tags>
                       <p class="description text-overflow" *ngIf="user && user.introduction">{{ user && user.introduction }}</p>
                     </div>
                   </div>


### PR DESCRIPTION
I've set a maximum of 4 visible tags on the project list page because 5 seemed too many as the tags tend to be longer, on average, than on the user list page.