### PR TITLE
One Line Job Title - Fix Issue #1728

### DIFF
--- a/src/app/_components/shared-btn/shared-btn.component.scss
+++ b/src/app/_components/shared-btn/shared-btn.component.scss
@@ -18,16 +18,21 @@
   }
   .btn.share-btn {
     padding: 0 1rem;
-    background-color: $main-color;
+    background-color: #fff;
+    border: 2px solid $secondary-bg-color;
+    color: $secondary-bg-color;
     &:hover {
-      background-color: $main-color;
+      background-color: $secondary-bg-color;
+      color: #fff;
     }
   }
+
   .btn-floating {
     text-align: center;
     background-color: $secondary-bg-color;
     &:hover {
       background-color: #fff;
+      border: 2px solid $secondary-bg-color;
     }
   }
 }

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -370,14 +370,14 @@
       <div class="col s6 toLower">
           <span style="font-size: 18px">Contribute to our open source project</span><br>
         <a class="btn btn_github" href="https://github.com/Code4SocialGood/" target="_blank">
-          Github Project<i class="mdi mdi-github-circle mdi-36px left" name="github"></i>
+          Github Project<i class="mdi mdi-github-circle mdi-24px left" name="github"></i>
         </a>        
       </div>
 
       <div class="col s6 toLower">
         <span style="font-size: 18px">Join our volunteer community</span><br>
         <a class="btn btn_github" href="http://join-our-slack.code4socialgood.org/" target="_blank">
-          Chat Room<i class="mdi mdi-slack mdi-36px left" name="slack"></i>
+          Chat Room<i class="mdi mdi-slack mdi-24px left" name="slack"></i>
         </a>        
       </div>
     </div>


### PR DESCRIPTION
This pull request fixes #1728.  The issue requested that the title be on one line only.  We created a new class that had not been used in other parts of the project, `.user-title.` We added the following three css properties to fix the issue: 

``` 
.user-title {
  overflow: hidden;
  text-overflow: ellipsis;
  white-space: nowrap;
}
```

Before:

<img width="729" alt="screen shot 2017-12-05 at 1 55 11 pm" src="https://user-images.githubusercontent.com/24993521/33630272-f742eeaa-d9c3-11e7-8435-6caf13b0ea40.png">

After:

<img width="727" alt="screen shot 2017-12-05 at 1 53 31 pm" src="https://user-images.githubusercontent.com/24993521/33630283-fdbeb2d2-d9c3-11e7-9783-677039a7f163.png">

our contribution team: @nikborn @johnmboudreaux @hsanchez7934 @robbiegreiner