### PR TITLE
Skills tag: remove formatter

### DIFF
--- a/src/app/project/edit/project-edit.component.html
+++ b/src/app/project/edit/project-edit.component.html
@@ -150,11 +150,11 @@
             <div class="col s6">
               <div class="input-field col s10 skills-margin">
                 <label [ngClass]="{active: inputValue}" for="newSkill">Enter additional skills
-                  <i class="material-icons tooltipped" materialize="tooltip" data-position="bottom" data-delay="10" 
-                  data-tooltip="Enter a skill with all small case, and one single word (could be multi words connected with dash)">info</i>
+                  <!-- <i class="material-icons tooltipped" materialize="tooltip" data-position="bottom" data-delay="10" 
+                  data-tooltip="Enter a skill with all small case, and one single word (could be multi words connected with dash)">info</i> -->
                 </label>
                
-                <input [maxlength]="100" id="newSkill" type="text" placeholder="" #inputSkill [(ngModel)]="inputValue" myInputFormatter [ngModelOptions]="{standalone: true}">
+                <input [maxlength]="100" id="newSkill" type="text" placeholder="" #inputSkill [(ngModel)]="inputValue" [ngModelOptions]="{standalone: true}">
               </div>
               <div class="col s2 skills-margin">
                 <a class="btn-floating btn waves-effect waves-light" (click)="onAddOwnSkill(inputSkill)"><i

--- a/src/app/user/edit/user-edit.component.html
+++ b/src/app/user/edit/user-edit.component.html
@@ -165,11 +165,11 @@
               <div class="col s12 m6">
                 <div class="input-field col s10 skills-margin">
                   <label [ngClass]="{active: inputValue}" for="newSkill">Enter additional skills
-                    <i class="material-icons tooltipped" materialize="tooltip" data-position="bottom" data-delay="10" 
-                    data-tooltip="Enter a skill with all small case, and one single word (could be multi words connected with dash)">info</i>
+                    <!-- <i class="material-icons tooltipped" materialize="tooltip" data-position="bottom" data-delay="10" 
+                    data-tooltip="Enter a skill with all small case, and one single word (could be multi words connected with dash)">info</i> -->
                   </label>
                   <input [maxlength]="100" id="newSkill" type="text" placeholder="" class="validate" #inputSkill [(ngModel)]="inputValue"
-                  myInputFormatter [ngModelOptions]="{standalone: true}">
+                   [ngModelOptions]="{standalone: true}">
                 </div>
                 <div class="col s2 skills-margin">
                   <a class="btn-floating btn waves-effect waves-light add-button" (click)="onAddOwnSkill(inputSkill)"><i


### PR DESCRIPTION
This PR removes the enforcing format for skills tags in User Edit and Project Edit pages.

It´s my first OS contribution, so please, send me feedback and take it easy on me :see_no_evil: 

Reference Issue: https://github.com/Code4SocialGood/c4sg-web/issues/1707
that references Issue: #1194 of 
PR: https://github.com/Code4SocialGood/c4sg-web/pull/1650/files
