### PR TITLE
Fix sharing by email

### DIFF
--- a/src/app/_components/shared-btn/shared-btn.component.ts
+++ b/src/app/_components/shared-btn/shared-btn.component.ts
@@ -49,8 +49,7 @@ export class SharedBtnComponent implements OnInit {
     const subject: string = encodeURIComponent(this.project.name);
     const body: string = encodeURIComponent(`${this.project.description}\n\n${this.origin}${location.pathname}`
     );
-    const href = `mailto:?subject=${subject}&body=${body}`;
-    this.openSharePopup(href);
+    location.href = `mailto:?subject=${subject}&body=${body}`;
   }
 
   shareOnLinkedin(event: MouseEvent): void {


### PR DESCRIPTION
Fixes #1553

Changes the way the "share" button opens the email client so that an extra, empty browser window isn't opened.