### PR TITLE
User informed when skill limit reached in My Settings

### DIFF
--- a/src/app/user/edit/user-edit.component.html
+++ b/src/app/user/edit/user-edit.component.html
@@ -147,6 +147,8 @@
           <div *ngIf="isVolunteer">
             <div class="row">
               <div class="content-title">My Skills</div>
+              <p *ngIf="userSkillsArray.length < 10">Select up to 10 skills.</p>
+              <p *ngIf="userSkillsArray.length == 10">You have reached the maximum allowed number of skills.</p>
             </div>
             <div class="row">
               <div class="col s10">
@@ -154,7 +156,7 @@
                 </my-select-skill>
               </div>
             </div>
-            <div class="row">
+            <div *ngIf="userSkillsArray.length < 10" class="row">
               <div class="col s12 m6 theme-select dropdown">
                 <label for="skillSelect">Choose from popular skills below</label>
                 <select class="browser-default" id="skillSelect" materialize="material_select" (change)="onAddListedSkill($event)">


### PR DESCRIPTION
The My Skills heading on the My Settings page now has a new subheading. The subheading informs the user that they can add up to 10 skills. Once the 10th skill has been added, the subheading changes to inform the user that they have the maximum allowed skills on their account. The skill selector drop-down and input are also removed from the page once the user reaches the skill limit, It returns when the user is no longer at the limit. This should fix #1813