### PR TITLE
 Featured Video Displaying Again on Home Page

### DIFF
--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -47,7 +47,7 @@
 
 <div class="maindiv">
     <div class="action">
-        <video autoplay playsinline loop muted>
+        <video *ngIf="true" autoplay playsinline loop muted onloadedmetadata="this.muted = true">
             <source src="/assets/video/small-overlay-texture.mp4" type="video/mp4">
             <!--<source src="/assets/video/small-overlay-texture.webm" type="video/webm">-->
             Your browser does not support the video tag.


### PR DESCRIPTION
This is my first attempt at displaying the featured video again on the home page. It should resolve #1831. I think Angular tries to autoplay the video before the video element is created in the DOM. In this Pull Request, Angular should now wait until the video element is created before trying to autoplay.